### PR TITLE
feat(task-assignment): add TaskAssignment entity, controller, service…

### DIFF
--- a/src/main/java/com/nexhub/backend/controller/TaskAssignmentController.java
+++ b/src/main/java/com/nexhub/backend/controller/TaskAssignmentController.java
@@ -1,0 +1,94 @@
+package com.nexhub.backend.controller;
+
+import com.nexhub.backend.dto.ApiResponse;
+import com.nexhub.backend.dto.taskassignment.TaskAssignmentRequest;
+import com.nexhub.backend.dto.taskassignment.TaskAssignmentResponse;
+import com.nexhub.backend.dto.taskassignment.TaskAssignmentUpdateRequest;
+import com.nexhub.backend.service.TaskAssignmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api/task-assignments")
+@RequiredArgsConstructor
+public class TaskAssignmentController {
+    private final TaskAssignmentService taskAssignmentService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<TaskAssignmentResponse>>> getAll() {
+        return ResponseEntity.ok(ApiResponse.success("List of task assignments", taskAssignmentService.getAllAssignments()));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<TaskAssignmentResponse>> getById(@PathVariable Long id) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success("Task assignment found", taskAssignmentService.getAssignmentById(id)));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+
+    @GetMapping("/task/{taskId}")
+    public ResponseEntity<ApiResponse<List<TaskAssignmentResponse>>> getByTask(@PathVariable Long taskId) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success("Task assignments", taskAssignmentService.getAssignmentsByTask(taskId)));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<ApiResponse<List<TaskAssignmentResponse>>> getByUser(@PathVariable Long userId) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success("User task assignments", taskAssignmentService.getAssignmentsByUser(userId)));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<TaskAssignmentResponse>> create(@RequestBody TaskAssignmentRequest request) {
+        try {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(ApiResponse.success("Task assignment created correctly", taskAssignmentService.createAssignment(request)));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+
+    @PostMapping("/updateassignment")
+    public ResponseEntity<ApiResponse<TaskAssignmentResponse>> update(@RequestBody TaskAssignmentUpdateRequest request) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success("Task assignment updated correctly", taskAssignmentService.updateAssignment(request)));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+
+    @PostMapping("/delete")
+    public ResponseEntity<ApiResponse<TaskAssignmentResponse>> delete(@RequestBody Long id) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success("Task assignment deleted successfully", taskAssignmentService.deleteAssignment(id)));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/nexhub/backend/dto/taskassignment/TaskAssignmentRequest.java
+++ b/src/main/java/com/nexhub/backend/dto/taskassignment/TaskAssignmentRequest.java
@@ -1,0 +1,7 @@
+package com.nexhub.backend.dto.taskassignment;
+
+public record TaskAssignmentRequest(
+        Long taskId,
+        Long userId
+) {
+}

--- a/src/main/java/com/nexhub/backend/dto/taskassignment/TaskAssignmentResponse.java
+++ b/src/main/java/com/nexhub/backend/dto/taskassignment/TaskAssignmentResponse.java
@@ -1,0 +1,40 @@
+package com.nexhub.backend.dto.taskassignment;
+
+import com.nexhub.backend.model.Project;
+import com.nexhub.backend.model.Task;
+import com.nexhub.backend.model.TaskAssignment;
+import com.nexhub.backend.model.User;
+
+import java.sql.Date;
+
+public record TaskAssignmentResponse(
+        Long id,
+        Long taskId,
+        String taskTitle,
+        Long projectId,
+        String projectName,
+        Long userId,
+        String username,
+        Date assignedAt,
+        String status,
+        Integer attemptsUsed
+) {
+    public static TaskAssignmentResponse fromTaskAssignment(TaskAssignment assignment) {
+        Task task = assignment.getTask();
+        Project project = task != null ? task.getProject() : null;
+        User user = assignment.getUser();
+
+        return new TaskAssignmentResponse(
+                assignment.getId(),
+                task != null ? task.getId() : null,
+                task != null ? task.getTitle() : null,
+                project != null ? project.getId() : null,
+                project != null ? project.getName() : null,
+                user != null ? user.getId() : null,
+                user != null ? user.getUsername() : null,
+                assignment.getAssignedAt(),
+                assignment.getStatus(),
+                assignment.getAttemptsUsed()
+        );
+    }
+}

--- a/src/main/java/com/nexhub/backend/dto/taskassignment/TaskAssignmentUpdateRequest.java
+++ b/src/main/java/com/nexhub/backend/dto/taskassignment/TaskAssignmentUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.nexhub.backend.dto.taskassignment;
+
+public record TaskAssignmentUpdateRequest(
+        Long id,
+        String status,
+        Integer attemptsUsed
+) {
+}

--- a/src/main/java/com/nexhub/backend/model/TaskAssignment.java
+++ b/src/main/java/com/nexhub/backend/model/TaskAssignment.java
@@ -1,0 +1,65 @@
+package com.nexhub.backend.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Date;
+
+@Entity
+@Table(name = "task_assignments")
+public class TaskAssignment {
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Getter
+    @Setter
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "task_id", nullable = false)
+    private Task task;
+
+    @Getter
+    @Setter
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Getter
+    @Setter
+    @Column(name = "assigned_at", nullable = false)
+    private Date assignedAt;
+
+    @Getter
+    @Setter
+    @Column(nullable = false)
+    private String status;
+
+    @Getter
+    @Setter
+    @Column(name = "attempts_used", nullable = false)
+    private Integer attemptsUsed;
+
+    @PrePersist
+    void prePersist() {
+        if (assignedAt == null) {
+            assignedAt = new Date(System.currentTimeMillis());
+        }
+        if (status == null || status.isBlank()) {
+            status = "active";
+        }
+        if (attemptsUsed == null || attemptsUsed < 0) {
+            attemptsUsed = 0;
+        }
+    }
+}

--- a/src/main/java/com/nexhub/backend/repository/TaskAssignmentRepository.java
+++ b/src/main/java/com/nexhub/backend/repository/TaskAssignmentRepository.java
@@ -1,0 +1,27 @@
+package com.nexhub.backend.repository;
+
+import com.nexhub.backend.model.TaskAssignment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface TaskAssignmentRepository extends JpaRepository<TaskAssignment, Long> {
+    @Query("select assignment from TaskAssignment assignment where assignment.task.id = :taskId order by assignment.assignedAt desc")
+    List<TaskAssignment> findByTaskIdOrderByAssignedAtDesc(@Param("taskId") Long taskId);
+
+    @Query("select assignment from TaskAssignment assignment where assignment.user.id = :userId order by assignment.assignedAt desc")
+    List<TaskAssignment> findByUserIdOrderByAssignedAtDesc(@Param("userId") Long userId);
+
+    @Query("""
+            select count(assignment) from TaskAssignment assignment
+            where assignment.task.id = :taskId
+            and lower(assignment.status) = 'active'
+            and (:assignmentIdToIgnore is null or assignment.id <> :assignmentIdToIgnore)
+            """)
+    Long countOtherActiveByTaskId(
+            @Param("taskId") Long taskId,
+            @Param("assignmentIdToIgnore") Long assignmentIdToIgnore
+    );
+}

--- a/src/main/java/com/nexhub/backend/service/TaskAssignmentService.java
+++ b/src/main/java/com/nexhub/backend/service/TaskAssignmentService.java
@@ -1,0 +1,166 @@
+package com.nexhub.backend.service;
+
+import com.nexhub.backend.dto.taskassignment.TaskAssignmentRequest;
+import com.nexhub.backend.dto.taskassignment.TaskAssignmentResponse;
+import com.nexhub.backend.dto.taskassignment.TaskAssignmentUpdateRequest;
+import com.nexhub.backend.model.Project;
+import com.nexhub.backend.model.Task;
+import com.nexhub.backend.model.TaskAssignment;
+import com.nexhub.backend.model.User;
+import com.nexhub.backend.repository.TaskAssignmentRepository;
+import com.nexhub.backend.repository.TaskRepository;
+import com.nexhub.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Date;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TaskAssignmentService {
+    private static final String ACTIVE_STATUS = "active";
+
+    private final TaskAssignmentRepository taskAssignmentRepository;
+    private final TaskRepository taskRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public List<TaskAssignmentResponse> getAllAssignments() {
+        return taskAssignmentRepository.findAll().stream()
+                .map(TaskAssignmentResponse::fromTaskAssignment)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public TaskAssignmentResponse getAssignmentById(Long id) {
+        return TaskAssignmentResponse.fromTaskAssignment(findExistingAssignment(id));
+    }
+
+    @Transactional(readOnly = true)
+    public List<TaskAssignmentResponse> getAssignmentsByTask(Long taskId) {
+        if (taskId == null) {
+            throw new IllegalArgumentException("Task id is required");
+        }
+
+        return taskAssignmentRepository.findByTaskIdOrderByAssignedAtDesc(taskId).stream()
+                .map(TaskAssignmentResponse::fromTaskAssignment)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TaskAssignmentResponse> getAssignmentsByUser(Long userId) {
+        if (userId == null) {
+            throw new IllegalArgumentException("User id is required");
+        }
+
+        return taskAssignmentRepository.findByUserIdOrderByAssignedAtDesc(userId).stream()
+                .map(TaskAssignmentResponse::fromTaskAssignment)
+                .toList();
+    }
+
+    public TaskAssignmentResponse createAssignment(TaskAssignmentRequest request) {
+        validateCreateRequest(request);
+
+        Task task = taskRepository.findById(request.taskId())
+                .orElseThrow(() -> new NoSuchElementException("Task not found"));
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(() -> new NoSuchElementException("User not found"));
+
+        validateUserCanTakeTask(task, user);
+        validateTaskHasNoActiveAssignment(task.getId(), null);
+
+        TaskAssignment assignment = new TaskAssignment();
+        assignment.setTask(task);
+        assignment.setUser(user);
+        assignment.setAssignedAt(now());
+        assignment.setStatus(ACTIVE_STATUS);
+        assignment.setAttemptsUsed(0);
+
+        return TaskAssignmentResponse.fromTaskAssignment(taskAssignmentRepository.save(assignment));
+    }
+
+    public TaskAssignmentResponse updateAssignment(TaskAssignmentUpdateRequest request) {
+        if (request == null || request.id() == null) {
+            throw new IllegalArgumentException("Assignment id is required");
+        }
+
+        TaskAssignment assignment = findExistingAssignment(request.id());
+
+        if (request.status() != null && !request.status().isBlank()) {
+            String status = normalizeStatus(request.status());
+            if (ACTIVE_STATUS.equals(status)) {
+                validateTaskHasNoActiveAssignment(assignment.getTask().getId(), assignment.getId());
+            }
+            assignment.setStatus(status);
+        }
+
+        if (request.attemptsUsed() != null) {
+            assignment.setAttemptsUsed(normalizeAttemptsUsed(request.attemptsUsed()));
+        }
+
+        return TaskAssignmentResponse.fromTaskAssignment(taskAssignmentRepository.save(assignment));
+    }
+
+    public TaskAssignmentResponse deleteAssignment(Long id) {
+        TaskAssignment assignment = findExistingAssignment(id);
+        TaskAssignmentResponse response = TaskAssignmentResponse.fromTaskAssignment(assignment);
+        taskAssignmentRepository.delete(assignment);
+        return response;
+    }
+
+    private TaskAssignment findExistingAssignment(Long id) {
+        if (id == null) {
+            throw new IllegalArgumentException("Assignment id is required");
+        }
+
+        return taskAssignmentRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Assignment not found"));
+    }
+
+    private void validateCreateRequest(TaskAssignmentRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("Assignment data is required");
+        }
+        if (request.taskId() == null) {
+            throw new IllegalArgumentException("Task id is required");
+        }
+        if (request.userId() == null) {
+            throw new IllegalArgumentException("User id is required");
+        }
+    }
+
+    private void validateUserCanTakeTask(Task task, User user) {
+        Project project = task.getProject();
+        User owner = project != null ? project.getOwner() : null;
+
+        if (owner != null && owner.getId() != null && owner.getId().equals(user.getId())) {
+            throw new IllegalArgumentException("Project owner cannot be assigned to their own task");
+        }
+    }
+
+    private void validateTaskHasNoActiveAssignment(Long taskId, Long assignmentIdToIgnore) {
+        Long activeAssignments = taskAssignmentRepository.countOtherActiveByTaskId(taskId, assignmentIdToIgnore);
+        if (activeAssignments != null && activeAssignments > 0) {
+            throw new IllegalArgumentException("Task already has an active assignment");
+        }
+    }
+
+    private String normalizeStatus(String status) {
+        return status.trim().toLowerCase();
+    }
+
+    private Integer normalizeAttemptsUsed(Integer attemptsUsed) {
+        if (attemptsUsed < 0) {
+            throw new IllegalArgumentException("Attempts used cannot be negative");
+        }
+        return attemptsUsed;
+    }
+
+    private Date now() {
+        return new Date(System.currentTimeMillis());
+    }
+}


### PR DESCRIPTION
…, repository, and DTOs

- Implemented `TaskAssignment` entity with persistence logic and pre-persist validations.
- Created `TaskAssignmentController` to manage task assignment API endpoints.
- Added `TaskAssignmentService` for business logic, including CRUD operations and validation.
- Built `TaskAssignmentRepository` with custom query methods for assignment retrieval.
- Introduced DTOs (`TaskAssignmentRequest`, `TaskAssignmentResponse`, `TaskAssignmentUpdateRequest`) for structured data handling.