### PR TITLE
feat(task-submission): add TaskSubmission entity, controller, service…

### DIFF
--- a/src/main/java/com/nexhub/backend/controller/TaskSubmissionController.java
+++ b/src/main/java/com/nexhub/backend/controller/TaskSubmissionController.java
@@ -1,0 +1,103 @@
+package com.nexhub.backend.controller;
+
+import com.nexhub.backend.dto.ApiResponse;
+import com.nexhub.backend.dto.tasksubmission.TaskSubmissionRequest;
+import com.nexhub.backend.dto.tasksubmission.TaskSubmissionResponse;
+import com.nexhub.backend.dto.tasksubmission.TaskSubmissionUpdateRequest;
+import com.nexhub.backend.service.TaskSubmissionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api/task-submissions")
+@RequiredArgsConstructor
+public class TaskSubmissionController {
+    private final TaskSubmissionService taskSubmissionService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<TaskSubmissionResponse>>> getAll() {
+        return ResponseEntity.ok(ApiResponse.success("List of task submissions", taskSubmissionService.getAllSubmissions()));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<TaskSubmissionResponse>> getById(@PathVariable Long id) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success("Task submission found", taskSubmissionService.getSubmissionById(id)));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+
+    @GetMapping("/task/{taskId}")
+    public ResponseEntity<ApiResponse<List<TaskSubmissionResponse>>> getByTask(@PathVariable Long taskId) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success("Task submissions", taskSubmissionService.getSubmissionsByTask(taskId)));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+
+    @GetMapping("/assignment/{assignmentId}")
+    public ResponseEntity<ApiResponse<List<TaskSubmissionResponse>>> getByAssignment(@PathVariable Long assignmentId) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success("Assignment submissions", taskSubmissionService.getSubmissionsByAssignment(assignmentId)));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<ApiResponse<List<TaskSubmissionResponse>>> getByUser(@PathVariable Long userId) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success("User task submissions", taskSubmissionService.getSubmissionsByUser(userId)));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<TaskSubmissionResponse>> create(@RequestBody TaskSubmissionRequest request) {
+        try {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(ApiResponse.success("Task submission created correctly", taskSubmissionService.createSubmission(request)));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+
+    @PostMapping("/updatesubmission")
+    public ResponseEntity<ApiResponse<TaskSubmissionResponse>> update(@RequestBody TaskSubmissionUpdateRequest request) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success("Task submission updated correctly", taskSubmissionService.updateSubmission(request)));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+
+    @PostMapping("/delete")
+    public ResponseEntity<ApiResponse<TaskSubmissionResponse>> delete(@RequestBody Long id) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success("Task submission deleted successfully", taskSubmissionService.deleteSubmission(id)));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/nexhub/backend/dto/tasksubmission/TaskSubmissionRequest.java
+++ b/src/main/java/com/nexhub/backend/dto/tasksubmission/TaskSubmissionRequest.java
@@ -1,0 +1,7 @@
+package com.nexhub.backend.dto.tasksubmission;
+
+public record TaskSubmissionRequest(
+        Long assignmentId,
+        String pullRequestUrl
+) {
+}

--- a/src/main/java/com/nexhub/backend/dto/tasksubmission/TaskSubmissionResponse.java
+++ b/src/main/java/com/nexhub/backend/dto/tasksubmission/TaskSubmissionResponse.java
@@ -1,0 +1,55 @@
+package com.nexhub.backend.dto.tasksubmission;
+
+import com.nexhub.backend.model.Project;
+import com.nexhub.backend.model.Task;
+import com.nexhub.backend.model.TaskAssignment;
+import com.nexhub.backend.model.TaskSubmission;
+import com.nexhub.backend.model.User;
+
+import java.sql.Date;
+
+public record TaskSubmissionResponse(
+        Long id,
+        Long taskId,
+        String taskTitle,
+        Long assignmentId,
+        Long projectId,
+        String projectName,
+        Long userId,
+        String username,
+        String pullRequestUrl,
+        Date submittedAt,
+        String status,
+        String reviewComments,
+        Date reviewedAt,
+        Long reviewerId,
+        String reviewerUsername,
+        Integer attemptsUsed
+) {
+    public static TaskSubmissionResponse fromTaskSubmission(TaskSubmission submission) {
+        Task task = submission.getTask();
+        TaskAssignment assignment = submission.getAssignment();
+        Project project = task != null ? task.getProject() : null;
+        User user = submission.getUser();
+        User reviewer = submission.getReviewer();
+
+        return new TaskSubmissionResponse(
+                submission.getId(),
+                task != null ? task.getId() : null,
+                task != null ? task.getTitle() : null,
+                assignment != null ? assignment.getId() : null,
+                project != null ? project.getId() : null,
+                project != null ? project.getName() : null,
+                user != null ? user.getId() : null,
+                user != null ? user.getUsername() : null,
+                submission.getPullRequestUrl(),
+                submission.getSubmittedAt(),
+                submission.getStatus(),
+                submission.getReviewComments(),
+                submission.getReviewedAt(),
+                reviewer != null ? reviewer.getId() : null,
+                reviewer != null ? reviewer.getUsername() : null,
+                submission.getAttemptsUsed()
+        );
+    }
+}

--- a/src/main/java/com/nexhub/backend/dto/tasksubmission/TaskSubmissionUpdateRequest.java
+++ b/src/main/java/com/nexhub/backend/dto/tasksubmission/TaskSubmissionUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.nexhub.backend.dto.tasksubmission;
+
+public record TaskSubmissionUpdateRequest(
+        Long id,
+        String pullRequestUrl,
+        String status,
+        String reviewComments,
+        Long reviewerId
+) {
+}

--- a/src/main/java/com/nexhub/backend/model/TaskSubmission.java
+++ b/src/main/java/com/nexhub/backend/model/TaskSubmission.java
@@ -1,0 +1,92 @@
+package com.nexhub.backend.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Date;
+
+@Entity
+@Table(name = "task_submissions")
+public class TaskSubmission {
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Getter
+    @Setter
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "task_id", nullable = false)
+    private Task task;
+
+    @Getter
+    @Setter
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "assignment_id", nullable = false)
+    private TaskAssignment assignment;
+
+    @Getter
+    @Setter
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Getter
+    @Setter
+    @Column(name = "pull_request_url", nullable = false, length = 500)
+    private String pullRequestUrl;
+
+    @Getter
+    @Setter
+    @Column(name = "submitted_at", nullable = false)
+    private Date submittedAt;
+
+    @Getter
+    @Setter
+    @Column(nullable = false)
+    private String status;
+
+    @Getter
+    @Setter
+    @Column(name = "review_comments", columnDefinition = "TEXT")
+    private String reviewComments;
+
+    @Getter
+    @Setter
+    @Column(name = "reviewed_at")
+    private Date reviewedAt;
+
+    @Getter
+    @Setter
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "reviewer_id")
+    private User reviewer;
+
+    @Getter
+    @Setter
+    @Column(name = "attempts_used", nullable = false)
+    private Integer attemptsUsed;
+
+    @PrePersist
+    void prePersist() {
+        if (submittedAt == null) {
+            submittedAt = new Date(System.currentTimeMillis());
+        }
+        if (status == null || status.isBlank()) {
+            status = "submitted";
+        }
+        if (attemptsUsed == null || attemptsUsed < 1) {
+            attemptsUsed = 1;
+        }
+    }
+}

--- a/src/main/java/com/nexhub/backend/repository/TaskSubmissionRepository.java
+++ b/src/main/java/com/nexhub/backend/repository/TaskSubmissionRepository.java
@@ -1,0 +1,19 @@
+package com.nexhub.backend.repository;
+
+import com.nexhub.backend.model.TaskSubmission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface TaskSubmissionRepository extends JpaRepository<TaskSubmission, Long> {
+    @Query("select submission from TaskSubmission submission where submission.task.id = :taskId order by submission.submittedAt desc")
+    List<TaskSubmission> findByTaskIdOrderBySubmittedAtDesc(@Param("taskId") Long taskId);
+
+    @Query("select submission from TaskSubmission submission where submission.assignment.id = :assignmentId order by submission.submittedAt desc")
+    List<TaskSubmission> findByAssignmentIdOrderBySubmittedAtDesc(@Param("assignmentId") Long assignmentId);
+
+    @Query("select submission from TaskSubmission submission where submission.user.id = :userId order by submission.submittedAt desc")
+    List<TaskSubmission> findByUserIdOrderBySubmittedAtDesc(@Param("userId") Long userId);
+}

--- a/src/main/java/com/nexhub/backend/service/TaskSubmissionService.java
+++ b/src/main/java/com/nexhub/backend/service/TaskSubmissionService.java
@@ -1,0 +1,292 @@
+package com.nexhub.backend.service;
+
+import com.nexhub.backend.dto.tasksubmission.TaskSubmissionRequest;
+import com.nexhub.backend.dto.tasksubmission.TaskSubmissionResponse;
+import com.nexhub.backend.dto.tasksubmission.TaskSubmissionUpdateRequest;
+import com.nexhub.backend.model.Project;
+import com.nexhub.backend.model.Task;
+import com.nexhub.backend.model.TaskAssignment;
+import com.nexhub.backend.model.TaskSubmission;
+import com.nexhub.backend.model.User;
+import com.nexhub.backend.repository.TaskAssignmentRepository;
+import com.nexhub.backend.repository.TaskSubmissionRepository;
+import com.nexhub.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Date;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TaskSubmissionService {
+    private static final String ACTIVE_ASSIGNMENT_STATUS = "active";
+    private static final String COMPLETED_ASSIGNMENT_STATUS = "completed";
+    private static final String SUBMITTED_STATUS = "submitted";
+    private static final String APPROVED_STATUS = "approved";
+    private static final String REJECTED_STATUS = "rejected";
+    private static final String CHANGES_REQUESTED_STATUS = "changes_requested";
+    private static final Set<String> ALLOWED_STATUSES = Set.of(
+            SUBMITTED_STATUS,
+            APPROVED_STATUS,
+            REJECTED_STATUS,
+            CHANGES_REQUESTED_STATUS
+    );
+
+    private final TaskSubmissionRepository taskSubmissionRepository;
+    private final TaskAssignmentRepository taskAssignmentRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public List<TaskSubmissionResponse> getAllSubmissions() {
+        return taskSubmissionRepository.findAll().stream()
+                .map(TaskSubmissionResponse::fromTaskSubmission)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public TaskSubmissionResponse getSubmissionById(Long id) {
+        return TaskSubmissionResponse.fromTaskSubmission(findExistingSubmission(id));
+    }
+
+    @Transactional(readOnly = true)
+    public List<TaskSubmissionResponse> getSubmissionsByTask(Long taskId) {
+        if (taskId == null) {
+            throw new IllegalArgumentException("Task id is required");
+        }
+
+        return taskSubmissionRepository.findByTaskIdOrderBySubmittedAtDesc(taskId).stream()
+                .map(TaskSubmissionResponse::fromTaskSubmission)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TaskSubmissionResponse> getSubmissionsByAssignment(Long assignmentId) {
+        if (assignmentId == null) {
+            throw new IllegalArgumentException("Assignment id is required");
+        }
+
+        return taskSubmissionRepository.findByAssignmentIdOrderBySubmittedAtDesc(assignmentId).stream()
+                .map(TaskSubmissionResponse::fromTaskSubmission)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TaskSubmissionResponse> getSubmissionsByUser(Long userId) {
+        if (userId == null) {
+            throw new IllegalArgumentException("User id is required");
+        }
+
+        return taskSubmissionRepository.findByUserIdOrderBySubmittedAtDesc(userId).stream()
+                .map(TaskSubmissionResponse::fromTaskSubmission)
+                .toList();
+    }
+
+    public TaskSubmissionResponse createSubmission(TaskSubmissionRequest request) {
+        validateCreateRequest(request);
+
+        TaskAssignment assignment = taskAssignmentRepository.findById(request.assignmentId())
+                .orElseThrow(() -> new NoSuchElementException("Assignment not found"));
+
+        validateAssignmentCanReceiveSubmission(assignment);
+
+        int nextAttempt = currentAttemptsUsed(assignment) + 1;
+        Task task = assignment.getTask();
+
+        TaskSubmission submission = new TaskSubmission();
+        submission.setAssignment(assignment);
+        submission.setTask(task);
+        submission.setUser(assignment.getUser());
+        submission.setPullRequestUrl(request.pullRequestUrl().trim());
+        submission.setSubmittedAt(now());
+        submission.setStatus(SUBMITTED_STATUS);
+        submission.setAttemptsUsed(nextAttempt);
+
+        assignment.setAttemptsUsed(nextAttempt);
+        taskAssignmentRepository.save(assignment);
+
+        return TaskSubmissionResponse.fromTaskSubmission(taskSubmissionRepository.save(submission));
+    }
+
+    public TaskSubmissionResponse updateSubmission(TaskSubmissionUpdateRequest request) {
+        if (request == null || request.id() == null) {
+            throw new IllegalArgumentException("Submission id is required");
+        }
+
+        TaskSubmission submission = findExistingSubmission(request.id());
+        String previousStatus = submission.getStatus();
+
+        if (request.pullRequestUrl() != null) {
+            validatePullRequestUrl(request.pullRequestUrl());
+            submission.setPullRequestUrl(request.pullRequestUrl().trim());
+        }
+
+        if (request.reviewComments() != null) {
+            submission.setReviewComments(normalizeOptionalText(request.reviewComments()));
+        }
+
+        if (request.status() != null && !request.status().isBlank()) {
+            String status = normalizeStatus(request.status());
+            submission.setStatus(status);
+
+            if (SUBMITTED_STATUS.equals(status)) {
+                submission.setReviewer(null);
+                submission.setReviewedAt(null);
+                syncAssignmentStatusAfterStatusChange(submission, previousStatus, status);
+            } else if (isReviewStatus(status)) {
+                User reviewer = findReviewer(request.reviewerId());
+                validateReviewerOwnsProject(reviewer, submission);
+                submission.setReviewer(reviewer);
+                submission.setReviewedAt(now());
+                syncAssignmentStatusAfterStatusChange(submission, previousStatus, status);
+            }
+        }
+
+        return TaskSubmissionResponse.fromTaskSubmission(taskSubmissionRepository.save(submission));
+    }
+
+    public TaskSubmissionResponse deleteSubmission(Long id) {
+        TaskSubmission submission = findExistingSubmission(id);
+        TaskSubmissionResponse response = TaskSubmissionResponse.fromTaskSubmission(submission);
+        taskSubmissionRepository.delete(submission);
+        return response;
+    }
+
+    private TaskSubmission findExistingSubmission(Long id) {
+        if (id == null) {
+            throw new IllegalArgumentException("Submission id is required");
+        }
+
+        return taskSubmissionRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Submission not found"));
+    }
+
+    private void validateCreateRequest(TaskSubmissionRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("Submission data is required");
+        }
+        if (request.assignmentId() == null) {
+            throw new IllegalArgumentException("Assignment id is required");
+        }
+        validatePullRequestUrl(request.pullRequestUrl());
+    }
+
+    private void validateAssignmentCanReceiveSubmission(TaskAssignment assignment) {
+        if (assignment.getTask() == null) {
+            throw new IllegalArgumentException("Assignment task is required");
+        }
+        if (assignment.getUser() == null) {
+            throw new IllegalArgumentException("Assignment user is required");
+        }
+        if (!ACTIVE_ASSIGNMENT_STATUS.equalsIgnoreCase(assignment.getStatus())) {
+            throw new IllegalArgumentException("Assignment must be active to submit work");
+        }
+
+        int maxAttempts = maxAttemptsForTask(assignment.getTask());
+        if (currentAttemptsUsed(assignment) >= maxAttempts) {
+            throw new IllegalArgumentException("Assignment has reached the maximum number of attempts");
+        }
+    }
+
+    private void validatePullRequestUrl(String pullRequestUrl) {
+        if (pullRequestUrl == null || pullRequestUrl.isBlank()) {
+            throw new IllegalArgumentException("Pull request URL is required");
+        }
+
+        try {
+            URI uri = new URI(pullRequestUrl.trim());
+            String scheme = uri.getScheme();
+            if (scheme == null
+                    || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))
+                    || uri.getHost() == null
+                    || uri.getHost().isBlank()) {
+                throw new IllegalArgumentException("Pull request URL must be a valid URL");
+            }
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Pull request URL must be a valid URL");
+        }
+    }
+
+    private User findReviewer(Long reviewerId) {
+        if (reviewerId == null) {
+            throw new IllegalArgumentException("Reviewer id is required");
+        }
+
+        return userRepository.findById(reviewerId)
+                .orElseThrow(() -> new NoSuchElementException("Reviewer not found"));
+    }
+
+    private void validateReviewerOwnsProject(User reviewer, TaskSubmission submission) {
+        Project project = submission.getTask() != null ? submission.getTask().getProject() : null;
+        User owner = project != null ? project.getOwner() : null;
+
+        if (owner == null || owner.getId() == null || !owner.getId().equals(reviewer.getId())) {
+            throw new IllegalArgumentException("Only the project owner can review this submission");
+        }
+    }
+
+    private void syncAssignmentStatusAfterStatusChange(TaskSubmission submission, String previousStatus, String status) {
+        TaskAssignment assignment = submission.getAssignment();
+        if (assignment == null) {
+            return;
+        }
+
+        if (APPROVED_STATUS.equals(status)) {
+            assignment.setStatus(COMPLETED_ASSIGNMENT_STATUS);
+            taskAssignmentRepository.save(assignment);
+            return;
+        }
+
+        if (APPROVED_STATUS.equalsIgnoreCase(previousStatus)) {
+            assignment.setStatus(ACTIVE_ASSIGNMENT_STATUS);
+            taskAssignmentRepository.save(assignment);
+        }
+    }
+
+    private boolean isReviewStatus(String status) {
+        return APPROVED_STATUS.equals(status)
+                || REJECTED_STATUS.equals(status)
+                || CHANGES_REQUESTED_STATUS.equals(status);
+    }
+
+    private String normalizeStatus(String status) {
+        String normalizedStatus = status.trim().toLowerCase();
+        if (!ALLOWED_STATUSES.contains(normalizedStatus)) {
+            throw new IllegalArgumentException("Submission status is invalid");
+        }
+        return normalizedStatus;
+    }
+
+    private String normalizeOptionalText(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private int currentAttemptsUsed(TaskAssignment assignment) {
+        Integer attemptsUsed = assignment.getAttemptsUsed();
+        if (attemptsUsed == null || attemptsUsed < 0) {
+            return 0;
+        }
+        return attemptsUsed;
+    }
+
+    private int maxAttemptsForTask(Task task) {
+        Integer maxAttempts = task.getMaxAttempts();
+        if (maxAttempts == null || maxAttempts < 1) {
+            return 1;
+        }
+        return maxAttempts;
+    }
+
+    private Date now() {
+        return new Date(System.currentTimeMillis());
+    }
+}


### PR DESCRIPTION
…, repository, and DTOs

- Implemented `TaskSubmission` entity with persistence logic and validation.
- Created `TaskSubmissionController` to handle API endpoints for task submissions.
- Added `TaskSubmissionService` for business logic, including CRUD functionalities and validation.
- Developed `TaskSubmissionRepository` with custom query methods for submission retrieval.
- Introduced DTOs (`TaskSubmissionRequest`, `TaskSubmissionResponse`, `TaskSubmissionUpdateRequest`) for structured data handling.