### PR TITLE
feat(pagination): implement pagination across entire backend.(no mires el nombre de la branch)

### DIFF
--- a/src/main/java/com/nexhub/backend/controller/ProjectController.java
+++ b/src/main/java/com/nexhub/backend/controller/ProjectController.java
@@ -1,16 +1,18 @@
 package com.nexhub.backend.controller;
 
 import com.nexhub.backend.dto.ApiResponse;
+import com.nexhub.backend.dto.PagedResponse;
 import com.nexhub.backend.dto.project.ProjectRequest;
 import com.nexhub.backend.dto.project.ProjectResponse;
 import com.nexhub.backend.dto.project.ProjectUpdateRequest;
 import com.nexhub.backend.service.ProjectService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.NoSuchElementException;
 
 @RestController
@@ -20,8 +22,10 @@ public class ProjectController {
     private final ProjectService projectService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<ProjectResponse>>> getAll() {
-        return ResponseEntity.ok(ApiResponse.success("List of projects", projectService.getAllProjects()));
+    public ResponseEntity<ApiResponse<PagedResponse<ProjectResponse>>> getAll(
+            @PageableDefault(size = 9) Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.success("List of projects", projectService.getAllProjects(pageable)));
     }
 
     @GetMapping("/{id}")
@@ -36,9 +40,12 @@ public class ProjectController {
     }
 
     @GetMapping("/findbytag")
-    public ResponseEntity<ApiResponse<List<ProjectResponse>>> getProjectsByTag(@RequestParam String tag) {
+    public ResponseEntity<ApiResponse<PagedResponse<ProjectResponse>>> getProjectsByTag(
+            @RequestParam String tag,
+            @PageableDefault(size = 9) Pageable pageable
+    ) {
         try {
-            return ResponseEntity.ok(ApiResponse.success("List of projects", projectService.getProjectsByTag(tag)));
+            return ResponseEntity.ok(ApiResponse.success("List of projects", projectService.getProjectsByTag(tag, pageable)));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
         }
@@ -101,9 +108,12 @@ public class ProjectController {
     }
 
     @GetMapping("/owner/{owner}")
-    public ResponseEntity<ApiResponse<List<ProjectResponse>>> getOwnedProjects(@PathVariable Long owner) {
+    public ResponseEntity<ApiResponse<PagedResponse<ProjectResponse>>> getOwnedProjects(
+            @PathVariable Long owner,
+            @PageableDefault(size = 9) Pageable pageable
+    ) {
         try {
-            return ResponseEntity.ok(ApiResponse.success("Projects", projectService.getProjectsByOwner(owner)));
+            return ResponseEntity.ok(ApiResponse.success("Projects", projectService.getProjectsByOwner(owner, pageable)));
         } catch (NoSuchElementException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(e.getMessage()));
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/nexhub/backend/controller/TaskAssignmentController.java
+++ b/src/main/java/com/nexhub/backend/controller/TaskAssignmentController.java
@@ -1,21 +1,25 @@
 package com.nexhub.backend.controller;
 
 import com.nexhub.backend.dto.ApiResponse;
+import com.nexhub.backend.dto.PagedResponse;
 import com.nexhub.backend.dto.taskassignment.TaskAssignmentRequest;
 import com.nexhub.backend.dto.taskassignment.TaskAssignmentResponse;
 import com.nexhub.backend.dto.taskassignment.TaskAssignmentUpdateRequest;
 import com.nexhub.backend.service.TaskAssignmentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 import java.util.NoSuchElementException;
 
 @RestController
@@ -25,8 +29,10 @@ public class TaskAssignmentController {
     private final TaskAssignmentService taskAssignmentService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<TaskAssignmentResponse>>> getAll() {
-        return ResponseEntity.ok(ApiResponse.success("List of task assignments", taskAssignmentService.getAllAssignments()));
+    public ResponseEntity<ApiResponse<PagedResponse<TaskAssignmentResponse>>> getAll(
+            @PageableDefault(size = 9, sort = "assignedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.success("List of task assignments", taskAssignmentService.getAllAssignments(pageable)));
     }
 
     @GetMapping("/{id}")
@@ -41,18 +47,25 @@ public class TaskAssignmentController {
     }
 
     @GetMapping("/task/{taskId}")
-    public ResponseEntity<ApiResponse<List<TaskAssignmentResponse>>> getByTask(@PathVariable Long taskId) {
+    public ResponseEntity<ApiResponse<PagedResponse<TaskAssignmentResponse>>> getByTask(
+            @PathVariable Long taskId,
+            @PageableDefault(size = 9, sort = "assignedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
         try {
-            return ResponseEntity.ok(ApiResponse.success("Task assignments", taskAssignmentService.getAssignmentsByTask(taskId)));
+            return ResponseEntity.ok(ApiResponse.success("Task assignments", taskAssignmentService.getAssignmentsByTask(taskId, pageable)));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
         }
     }
 
     @GetMapping("/user/{userId}")
-    public ResponseEntity<ApiResponse<List<TaskAssignmentResponse>>> getByUser(@PathVariable Long userId) {
+    public ResponseEntity<ApiResponse<PagedResponse<TaskAssignmentResponse>>> getByUser(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "false") boolean openOnly,
+            @PageableDefault(size = 9, sort = "assignedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
         try {
-            return ResponseEntity.ok(ApiResponse.success("User task assignments", taskAssignmentService.getAssignmentsByUser(userId)));
+            return ResponseEntity.ok(ApiResponse.success("User task assignments", taskAssignmentService.getAssignmentsByUser(userId, pageable, openOnly)));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
         }

--- a/src/main/java/com/nexhub/backend/controller/TaskController.java
+++ b/src/main/java/com/nexhub/backend/controller/TaskController.java
@@ -1,16 +1,18 @@
 package com.nexhub.backend.controller;
 
 import com.nexhub.backend.dto.ApiResponse;
+import com.nexhub.backend.dto.PagedResponse;
 import com.nexhub.backend.dto.task.TaskRequest;
 import com.nexhub.backend.dto.task.TaskResponse;
 import com.nexhub.backend.dto.task.TaskUpdateRequest;
 import com.nexhub.backend.service.TaskService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.NoSuchElementException;
 
 @RestController
@@ -20,8 +22,22 @@ public class TaskController {
     private final TaskService taskService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<TaskResponse>>> getAll() {
-        return ResponseEntity.ok(ApiResponse.success("List of tasks", taskService.getAllTasks()));
+    public ResponseEntity<ApiResponse<PagedResponse<TaskResponse>>> getAll(
+            @PageableDefault(size = 9) Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.success("List of tasks", taskService.getAllTasks(pageable)));
+    }
+
+    @GetMapping("/owner/{ownerId}")
+    public ResponseEntity<ApiResponse<PagedResponse<TaskResponse>>> getByOwner(
+            @PathVariable Long ownerId,
+            @PageableDefault(size = 9) Pageable pageable
+    ) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success("Owner tasks", taskService.getTasksByOwner(ownerId, pageable)));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
     }
 
     @GetMapping("/{id}")
@@ -36,9 +52,12 @@ public class TaskController {
     }
 
     @GetMapping("/project/{projectId}")
-    public ResponseEntity<ApiResponse<List<TaskResponse>>> getByProject(@PathVariable Long projectId) {
+    public ResponseEntity<ApiResponse<PagedResponse<TaskResponse>>> getByProject(
+            @PathVariable Long projectId,
+            @PageableDefault(size = 9) Pageable pageable
+    ) {
         try {
-            return ResponseEntity.ok(ApiResponse.success("List of tasks", taskService.getTasksByProject(projectId)));
+            return ResponseEntity.ok(ApiResponse.success("List of tasks", taskService.getTasksByProject(projectId, pageable)));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
         }

--- a/src/main/java/com/nexhub/backend/controller/TaskSubmissionController.java
+++ b/src/main/java/com/nexhub/backend/controller/TaskSubmissionController.java
@@ -1,21 +1,25 @@
 package com.nexhub.backend.controller;
 
 import com.nexhub.backend.dto.ApiResponse;
+import com.nexhub.backend.dto.PagedResponse;
 import com.nexhub.backend.dto.tasksubmission.TaskSubmissionRequest;
 import com.nexhub.backend.dto.tasksubmission.TaskSubmissionResponse;
 import com.nexhub.backend.dto.tasksubmission.TaskSubmissionUpdateRequest;
 import com.nexhub.backend.service.TaskSubmissionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 import java.util.NoSuchElementException;
 
 @RestController
@@ -25,8 +29,10 @@ public class TaskSubmissionController {
     private final TaskSubmissionService taskSubmissionService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<TaskSubmissionResponse>>> getAll() {
-        return ResponseEntity.ok(ApiResponse.success("List of task submissions", taskSubmissionService.getAllSubmissions()));
+    public ResponseEntity<ApiResponse<PagedResponse<TaskSubmissionResponse>>> getAll(
+            @PageableDefault(size = 9, sort = "submittedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.success("List of task submissions", taskSubmissionService.getAllSubmissions(pageable)));
     }
 
     @GetMapping("/{id}")
@@ -41,27 +47,52 @@ public class TaskSubmissionController {
     }
 
     @GetMapping("/task/{taskId}")
-    public ResponseEntity<ApiResponse<List<TaskSubmissionResponse>>> getByTask(@PathVariable Long taskId) {
+    public ResponseEntity<ApiResponse<PagedResponse<TaskSubmissionResponse>>> getByTask(
+            @PathVariable Long taskId,
+            @PageableDefault(size = 9, sort = "submittedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
         try {
-            return ResponseEntity.ok(ApiResponse.success("Task submissions", taskSubmissionService.getSubmissionsByTask(taskId)));
+            return ResponseEntity.ok(ApiResponse.success("Task submissions", taskSubmissionService.getSubmissionsByTask(taskId, pageable)));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
         }
     }
 
     @GetMapping("/assignment/{assignmentId}")
-    public ResponseEntity<ApiResponse<List<TaskSubmissionResponse>>> getByAssignment(@PathVariable Long assignmentId) {
+    public ResponseEntity<ApiResponse<PagedResponse<TaskSubmissionResponse>>> getByAssignment(
+            @PathVariable Long assignmentId,
+            @PageableDefault(size = 9, sort = "submittedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
         try {
-            return ResponseEntity.ok(ApiResponse.success("Assignment submissions", taskSubmissionService.getSubmissionsByAssignment(assignmentId)));
+            return ResponseEntity.ok(ApiResponse.success("Assignment submissions", taskSubmissionService.getSubmissionsByAssignment(assignmentId, pageable)));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
         }
     }
 
     @GetMapping("/user/{userId}")
-    public ResponseEntity<ApiResponse<List<TaskSubmissionResponse>>> getByUser(@PathVariable Long userId) {
+    public ResponseEntity<ApiResponse<PagedResponse<TaskSubmissionResponse>>> getByUser(
+            @PathVariable Long userId,
+            @PageableDefault(size = 9, sort = "submittedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
         try {
-            return ResponseEntity.ok(ApiResponse.success("User task submissions", taskSubmissionService.getSubmissionsByUser(userId)));
+            return ResponseEntity.ok(ApiResponse.success("User task submissions", taskSubmissionService.getSubmissionsByUser(userId, pageable)));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
+        }
+    }
+
+    @GetMapping("/reviewer/{reviewerId}")
+    public ResponseEntity<ApiResponse<PagedResponse<TaskSubmissionResponse>>> getByReviewer(
+            @PathVariable Long reviewerId,
+            @RequestParam(required = false) String status,
+            @PageableDefault(size = 9, sort = "submittedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        try {
+            return ResponseEntity.ok(ApiResponse.success(
+                    "Reviewer task submissions",
+                    taskSubmissionService.getSubmissionsToReview(reviewerId, status, pageable)
+            ));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(e.getMessage()));
         }

--- a/src/main/java/com/nexhub/backend/dto/PagedResponse.java
+++ b/src/main/java/com/nexhub/backend/dto/PagedResponse.java
@@ -1,0 +1,31 @@
+package com.nexhub.backend.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PagedResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean first,
+        boolean last,
+        boolean hasNext,
+        boolean hasPrevious
+) {
+    public static <T> PagedResponse<T> fromPage(Page<T> page) {
+        return new PagedResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isFirst(),
+                page.isLast(),
+                page.hasNext(),
+                page.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/com/nexhub/backend/repository/ProjectRepository.java
+++ b/src/main/java/com/nexhub/backend/repository/ProjectRepository.java
@@ -1,16 +1,17 @@
 package com.nexhub.backend.repository;
 
 import com.nexhub.backend.model.Project;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     Optional<Project> findByName(String name);
 
-    List<Project> findDistinctByTags_NameIgnoreCase(String tagName);
-    List<Project> findByOwner_Id(Long id);
+    Page<Project> findDistinctByTags_NameIgnoreCase(String tagName, Pageable pageable);
+    Page<Project> findByOwner_Id(Long id, Pageable pageable);
     boolean existsByOwner_Id(Long ownerId);
     boolean existsByContributors_Id(Long contributorId);
 }

--- a/src/main/java/com/nexhub/backend/repository/TaskAssignmentRepository.java
+++ b/src/main/java/com/nexhub/backend/repository/TaskAssignmentRepository.java
@@ -1,21 +1,28 @@
 package com.nexhub.backend.repository;
 
 import com.nexhub.backend.model.TaskAssignment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface TaskAssignmentRepository extends JpaRepository<TaskAssignment, Long> {
     boolean existsByTask_Id(Long taskId);
     boolean existsByUser_Id(Long userId);
 
-    @Query("select assignment from TaskAssignment assignment where assignment.task.id = :taskId order by assignment.assignedAt desc")
-    List<TaskAssignment> findByTaskIdOrderByAssignedAtDesc(@Param("taskId") Long taskId);
+    @Query("select assignment from TaskAssignment assignment where assignment.task.id = :taskId")
+    Page<TaskAssignment> findByTaskId(@Param("taskId") Long taskId, Pageable pageable);
 
-    @Query("select assignment from TaskAssignment assignment where assignment.user.id = :userId order by assignment.assignedAt desc")
-    List<TaskAssignment> findByUserIdOrderByAssignedAtDesc(@Param("userId") Long userId);
+    @Query("select assignment from TaskAssignment assignment where assignment.user.id = :userId")
+    Page<TaskAssignment> findByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("""
+            select assignment from TaskAssignment assignment
+            where assignment.user.id = :userId
+            and lower(assignment.status) not in ('completed', 'cancelled')
+            """)
+    Page<TaskAssignment> findOpenByUserId(@Param("userId") Long userId, Pageable pageable);
 
     @Query("""
             select count(assignment) from TaskAssignment assignment

--- a/src/main/java/com/nexhub/backend/repository/TaskRepository.java
+++ b/src/main/java/com/nexhub/backend/repository/TaskRepository.java
@@ -1,26 +1,31 @@
 package com.nexhub.backend.repository;
 
 import com.nexhub.backend.model.Task;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface TaskRepository extends JpaRepository<Task, Long> {
     boolean existsByProject_Id(Long projectId);
 
-    @Query("select task from Task task where task.project.id = :projectId order by task.created_at desc")
-    List<Task> findByProjectIdOrderByCreated_atDesc(@Param("projectId") Long projectId);
+    @Query("select task from Task task where lower(task.status) <> 'cancelled'")
+    Page<Task> findAllVisible(Pageable pageable);
 
-    @Query("select task from Task task where lower(task.status) = lower(:status) order by task.created_at desc")
-    List<Task> findByStatusIgnoreCaseOrderByCreated_atDesc(@Param("status") String status);
+    @Query("select task from Task task where task.project.id = :projectId")
+    Page<Task> findByProjectId(@Param("projectId") Long projectId, Pageable pageable);
+
+    @Query("select task from Task task where task.project.owner.id = :ownerId")
+    Page<Task> findByProjectOwnerId(@Param("ownerId") Long ownerId, Pageable pageable);
+
+    @Query("select task from Task task where lower(task.status) = lower(:status)")
+    Page<Task> findByStatusIgnoreCase(@Param("status") String status, Pageable pageable);
 
     @Query("""
             select distinct task from Task task
             join task.recommendedSkills skill
             where lower(skill.name) = lower(:skillName)
-            order by task.created_at desc
             """)
-    List<Task> findDistinctByRecommendedSkills_NameIgnoreCaseOrderByCreated_atDesc(@Param("skillName") String skillName);
+    Page<Task> findDistinctByRecommendedSkills_NameIgnoreCase(@Param("skillName") String skillName, Pageable pageable);
 }

--- a/src/main/java/com/nexhub/backend/repository/TaskSubmissionRepository.java
+++ b/src/main/java/com/nexhub/backend/repository/TaskSubmissionRepository.java
@@ -1,23 +1,37 @@
 package com.nexhub.backend.repository;
 
 import com.nexhub.backend.model.TaskSubmission;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface TaskSubmissionRepository extends JpaRepository<TaskSubmission, Long> {
     boolean existsByTask_Id(Long taskId);
     boolean existsByUser_Id(Long userId);
     boolean existsByReviewer_Id(Long reviewerId);
 
-    @Query("select submission from TaskSubmission submission where submission.task.id = :taskId order by submission.submittedAt desc")
-    List<TaskSubmission> findByTaskIdOrderBySubmittedAtDesc(@Param("taskId") Long taskId);
+    @Query("select submission from TaskSubmission submission where submission.task.id = :taskId")
+    Page<TaskSubmission> findByTaskId(@Param("taskId") Long taskId, Pageable pageable);
 
-    @Query("select submission from TaskSubmission submission where submission.assignment.id = :assignmentId order by submission.submittedAt desc")
-    List<TaskSubmission> findByAssignmentIdOrderBySubmittedAtDesc(@Param("assignmentId") Long assignmentId);
+    @Query("select submission from TaskSubmission submission where submission.assignment.id = :assignmentId")
+    Page<TaskSubmission> findByAssignmentId(@Param("assignmentId") Long assignmentId, Pageable pageable);
 
-    @Query("select submission from TaskSubmission submission where submission.user.id = :userId order by submission.submittedAt desc")
-    List<TaskSubmission> findByUserIdOrderBySubmittedAtDesc(@Param("userId") Long userId);
+    @Query("select submission from TaskSubmission submission where submission.user.id = :userId")
+    Page<TaskSubmission> findByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("select submission from TaskSubmission submission where submission.task.project.owner.id = :reviewerId")
+    Page<TaskSubmission> findByProjectOwnerId(@Param("reviewerId") Long reviewerId, Pageable pageable);
+
+    @Query("""
+            select submission from TaskSubmission submission
+            where submission.task.project.owner.id = :reviewerId
+            and lower(submission.status) = lower(:status)
+            """)
+    Page<TaskSubmission> findByProjectOwnerIdAndStatus(
+            @Param("reviewerId") Long reviewerId,
+            @Param("status") String status,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/nexhub/backend/service/ProjectService.java
+++ b/src/main/java/com/nexhub/backend/service/ProjectService.java
@@ -3,6 +3,7 @@ package com.nexhub.backend.service;
 import com.nexhub.backend.dto.project.ProjectRequest;
 import com.nexhub.backend.dto.project.ProjectResponse;
 import com.nexhub.backend.dto.project.ProjectUpdateRequest;
+import com.nexhub.backend.dto.PagedResponse;
 import com.nexhub.backend.model.Project;
 import com.nexhub.backend.model.Tag;
 import com.nexhub.backend.model.User;
@@ -11,11 +12,14 @@ import com.nexhub.backend.repository.TagRepository;
 import com.nexhub.backend.repository.TaskRepository;
 import com.nexhub.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Date;
-import java.util.*;
+import java.util.LinkedHashSet;
+import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 @Service
@@ -31,10 +35,10 @@ public class ProjectService {
     private final TaskRepository taskRepository;
 
     @Transactional(readOnly = true)
-    public List<ProjectResponse> getAllProjects() {
-        return projectRepository.findAll().stream()
-                .map(ProjectResponse::fromProject)
-                .toList();
+    public PagedResponse<ProjectResponse> getAllProjects(Pageable pageable) {
+        return PagedResponse.fromPage(
+                projectRepository.findAll(pageable).map(ProjectResponse::fromProject)
+        );
     }
 
     @Transactional(readOnly = true)
@@ -43,14 +47,15 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProjectResponse> getProjectsByTag(String tag) {
+    public PagedResponse<ProjectResponse> getProjectsByTag(String tag, Pageable pageable) {
         if (tag == null || tag.isBlank()) {
             throw new IllegalArgumentException("Tag is required");
         }
 
-        return projectRepository.findDistinctByTags_NameIgnoreCase(tag.trim()).stream()
-                .map(ProjectResponse::fromProject)
-                .toList();
+        return PagedResponse.fromPage(
+                projectRepository.findDistinctByTags_NameIgnoreCase(tag.trim(), pageable)
+                        .map(ProjectResponse::fromProject)
+        );
     }
 
     public ProjectResponse createProject(ProjectRequest request) {
@@ -207,11 +212,14 @@ public class ProjectService {
         return new Date(System.currentTimeMillis());
     }
 
-    public List<ProjectResponse> getProjectsByOwner(Long ownerId) {
-        List<Project> projects = projectRepository.findByOwner_Id(ownerId);
-        List<ProjectResponse> projectResponses = new ArrayList<>();
-        for (Project project : projects)
-            projectResponses.add(ProjectResponse.fromProject(project));
-        return projectResponses;
+    public PagedResponse<ProjectResponse> getProjectsByOwner(Long ownerId, Pageable pageable) {
+        if (ownerId == null) {
+            throw new IllegalArgumentException("Owner id is required");
+        }
+
+        return PagedResponse.fromPage(
+                projectRepository.findByOwner_Id(ownerId, pageable)
+                        .map(ProjectResponse::fromProject)
+        );
     }
 }

--- a/src/main/java/com/nexhub/backend/service/TaskAssignmentService.java
+++ b/src/main/java/com/nexhub/backend/service/TaskAssignmentService.java
@@ -1,5 +1,6 @@
 package com.nexhub.backend.service;
 
+import com.nexhub.backend.dto.PagedResponse;
 import com.nexhub.backend.dto.taskassignment.TaskAssignmentRequest;
 import com.nexhub.backend.dto.taskassignment.TaskAssignmentResponse;
 import com.nexhub.backend.dto.taskassignment.TaskAssignmentUpdateRequest;
@@ -11,11 +12,11 @@ import com.nexhub.backend.repository.TaskAssignmentRepository;
 import com.nexhub.backend.repository.TaskRepository;
 import com.nexhub.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Date;
-import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -29,10 +30,10 @@ public class TaskAssignmentService {
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
-    public List<TaskAssignmentResponse> getAllAssignments() {
-        return taskAssignmentRepository.findAll().stream()
-                .map(TaskAssignmentResponse::fromTaskAssignment)
-                .toList();
+    public PagedResponse<TaskAssignmentResponse> getAllAssignments(Pageable pageable) {
+        return PagedResponse.fromPage(
+                taskAssignmentRepository.findAll(pageable).map(TaskAssignmentResponse::fromTaskAssignment)
+        );
     }
 
     @Transactional(readOnly = true)
@@ -41,25 +42,34 @@ public class TaskAssignmentService {
     }
 
     @Transactional(readOnly = true)
-    public List<TaskAssignmentResponse> getAssignmentsByTask(Long taskId) {
+    public PagedResponse<TaskAssignmentResponse> getAssignmentsByTask(Long taskId, Pageable pageable) {
         if (taskId == null) {
             throw new IllegalArgumentException("Task id is required");
         }
 
-        return taskAssignmentRepository.findByTaskIdOrderByAssignedAtDesc(taskId).stream()
-                .map(TaskAssignmentResponse::fromTaskAssignment)
-                .toList();
+        return PagedResponse.fromPage(
+                taskAssignmentRepository.findByTaskId(taskId, pageable)
+                        .map(TaskAssignmentResponse::fromTaskAssignment)
+        );
     }
 
     @Transactional(readOnly = true)
-    public List<TaskAssignmentResponse> getAssignmentsByUser(Long userId) {
+    public PagedResponse<TaskAssignmentResponse> getAssignmentsByUser(Long userId, Pageable pageable, boolean openOnly) {
         if (userId == null) {
             throw new IllegalArgumentException("User id is required");
         }
 
-        return taskAssignmentRepository.findByUserIdOrderByAssignedAtDesc(userId).stream()
-                .map(TaskAssignmentResponse::fromTaskAssignment)
-                .toList();
+        if (openOnly) {
+            return PagedResponse.fromPage(
+                    taskAssignmentRepository.findOpenByUserId(userId, pageable)
+                            .map(TaskAssignmentResponse::fromTaskAssignment)
+            );
+        }
+
+        return PagedResponse.fromPage(
+                taskAssignmentRepository.findByUserId(userId, pageable)
+                        .map(TaskAssignmentResponse::fromTaskAssignment)
+        );
     }
 
     public TaskAssignmentResponse createAssignment(TaskAssignmentRequest request) {

--- a/src/main/java/com/nexhub/backend/service/TaskService.java
+++ b/src/main/java/com/nexhub/backend/service/TaskService.java
@@ -1,5 +1,6 @@
 package com.nexhub.backend.service;
 
+import com.nexhub.backend.dto.PagedResponse;
 import com.nexhub.backend.dto.task.TaskRequest;
 import com.nexhub.backend.dto.task.TaskResponse;
 import com.nexhub.backend.dto.task.TaskUpdateRequest;
@@ -12,13 +13,13 @@ import com.nexhub.backend.repository.TaskAssignmentRepository;
 import com.nexhub.backend.repository.TaskRepository;
 import com.nexhub.backend.repository.TaskSubmissionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -33,10 +34,10 @@ public class TaskService {
     private final TaskSubmissionRepository taskSubmissionRepository;
 
     @Transactional(readOnly = true)
-    public List<TaskResponse> getAllTasks() {
-        return taskRepository.findAll().stream()
-                .map(TaskResponse::fromTask)
-                .toList();
+    public PagedResponse<TaskResponse> getAllTasks(Pageable pageable) {
+        return PagedResponse.fromPage(
+                taskRepository.findAllVisible(pageable).map(TaskResponse::fromTask)
+        );
     }
 
     @Transactional(readOnly = true)
@@ -45,14 +46,27 @@ public class TaskService {
     }
 
     @Transactional(readOnly = true)
-    public List<TaskResponse> getTasksByProject(Long projectId) {
+    public PagedResponse<TaskResponse> getTasksByProject(Long projectId, Pageable pageable) {
         if (projectId == null) {
             throw new IllegalArgumentException("Project id is required");
         }
 
-        return taskRepository.findByProjectIdOrderByCreated_atDesc(projectId).stream()
-                .map(TaskResponse::fromTask)
-                .toList();
+        return PagedResponse.fromPage(
+                taskRepository.findByProjectId(projectId, pageable)
+                        .map(TaskResponse::fromTask)
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponse<TaskResponse> getTasksByOwner(Long ownerId, Pageable pageable) {
+        if (ownerId == null) {
+            throw new IllegalArgumentException("Owner id is required");
+        }
+
+        return PagedResponse.fromPage(
+                taskRepository.findByProjectOwnerId(ownerId, pageable)
+                        .map(TaskResponse::fromTask)
+        );
     }
 
     public TaskResponse createTask(TaskRequest request) {

--- a/src/main/java/com/nexhub/backend/service/TaskSubmissionService.java
+++ b/src/main/java/com/nexhub/backend/service/TaskSubmissionService.java
@@ -1,5 +1,6 @@
 package com.nexhub.backend.service;
 
+import com.nexhub.backend.dto.PagedResponse;
 import com.nexhub.backend.dto.tasksubmission.TaskSubmissionRequest;
 import com.nexhub.backend.dto.tasksubmission.TaskSubmissionResponse;
 import com.nexhub.backend.dto.tasksubmission.TaskSubmissionUpdateRequest;
@@ -12,13 +13,13 @@ import com.nexhub.backend.repository.TaskAssignmentRepository;
 import com.nexhub.backend.repository.TaskSubmissionRepository;
 import com.nexhub.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.Date;
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -44,10 +45,10 @@ public class TaskSubmissionService {
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
-    public List<TaskSubmissionResponse> getAllSubmissions() {
-        return taskSubmissionRepository.findAll().stream()
-                .map(TaskSubmissionResponse::fromTaskSubmission)
-                .toList();
+    public PagedResponse<TaskSubmissionResponse> getAllSubmissions(Pageable pageable) {
+        return PagedResponse.fromPage(
+                taskSubmissionRepository.findAll(pageable).map(TaskSubmissionResponse::fromTaskSubmission)
+        );
     }
 
     @Transactional(readOnly = true)
@@ -56,36 +57,58 @@ public class TaskSubmissionService {
     }
 
     @Transactional(readOnly = true)
-    public List<TaskSubmissionResponse> getSubmissionsByTask(Long taskId) {
+    public PagedResponse<TaskSubmissionResponse> getSubmissionsByTask(Long taskId, Pageable pageable) {
         if (taskId == null) {
             throw new IllegalArgumentException("Task id is required");
         }
 
-        return taskSubmissionRepository.findByTaskIdOrderBySubmittedAtDesc(taskId).stream()
-                .map(TaskSubmissionResponse::fromTaskSubmission)
-                .toList();
+        return PagedResponse.fromPage(
+                taskSubmissionRepository.findByTaskId(taskId, pageable)
+                        .map(TaskSubmissionResponse::fromTaskSubmission)
+        );
     }
 
     @Transactional(readOnly = true)
-    public List<TaskSubmissionResponse> getSubmissionsByAssignment(Long assignmentId) {
+    public PagedResponse<TaskSubmissionResponse> getSubmissionsByAssignment(Long assignmentId, Pageable pageable) {
         if (assignmentId == null) {
             throw new IllegalArgumentException("Assignment id is required");
         }
 
-        return taskSubmissionRepository.findByAssignmentIdOrderBySubmittedAtDesc(assignmentId).stream()
-                .map(TaskSubmissionResponse::fromTaskSubmission)
-                .toList();
+        return PagedResponse.fromPage(
+                taskSubmissionRepository.findByAssignmentId(assignmentId, pageable)
+                        .map(TaskSubmissionResponse::fromTaskSubmission)
+        );
     }
 
     @Transactional(readOnly = true)
-    public List<TaskSubmissionResponse> getSubmissionsByUser(Long userId) {
+    public PagedResponse<TaskSubmissionResponse> getSubmissionsByUser(Long userId, Pageable pageable) {
         if (userId == null) {
             throw new IllegalArgumentException("User id is required");
         }
 
-        return taskSubmissionRepository.findByUserIdOrderBySubmittedAtDesc(userId).stream()
-                .map(TaskSubmissionResponse::fromTaskSubmission)
-                .toList();
+        return PagedResponse.fromPage(
+                taskSubmissionRepository.findByUserId(userId, pageable)
+                        .map(TaskSubmissionResponse::fromTaskSubmission)
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponse<TaskSubmissionResponse> getSubmissionsToReview(Long reviewerId, String status, Pageable pageable) {
+        if (reviewerId == null) {
+            throw new IllegalArgumentException("Reviewer id is required");
+        }
+
+        if (status != null && !status.isBlank()) {
+            return PagedResponse.fromPage(
+                    taskSubmissionRepository.findByProjectOwnerIdAndStatus(reviewerId, status.trim(), pageable)
+                            .map(TaskSubmissionResponse::fromTaskSubmission)
+            );
+        }
+
+        return PagedResponse.fromPage(
+                taskSubmissionRepository.findByProjectOwnerId(reviewerId, pageable)
+                        .map(TaskSubmissionResponse::fromTaskSubmission)
+        );
     }
 
     public TaskSubmissionResponse createSubmission(TaskSubmissionRequest request) {

--- a/src/test/java/com/nexhub/backend/controller/AuthControllerTest.java
+++ b/src/test/java/com/nexhub/backend/controller/AuthControllerTest.java
@@ -82,7 +82,7 @@ class AuthControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status").value("success"))
                     .andExpect(jsonPath("$.message").value("Login exitoso"))
-                    .andExpect(jsonPath("$.data.username").value("manu"));
+                    .andExpect(jsonPath("$.data.user.username").value("manu"));
         }
 
         @Test

--- a/src/test/java/com/nexhub/backend/controller/ProjectControllerTest.java
+++ b/src/test/java/com/nexhub/backend/controller/ProjectControllerTest.java
@@ -1,5 +1,6 @@
 package com.nexhub.backend.controller;
 
+import com.nexhub.backend.dto.PagedResponse;
 import com.nexhub.backend.dto.project.ProjectResponse;
 import com.nexhub.backend.service.ProjectService;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +11,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -33,7 +37,9 @@ class ProjectControllerTest {
 
     @BeforeEach
     void setUp() {
-        mockMvc = MockMvcBuilders.standaloneSetup(new ProjectController(projectService)).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(new ProjectController(projectService))
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .build();
     }
 
     @Nested
@@ -42,13 +48,13 @@ class ProjectControllerTest {
 
         @Test
         void returnsListOfProjects() throws Exception {
-            when(projectService.getAllProjects()).thenReturn(List.of(sampleResponse()));
+            when(projectService.getAllProjects(org.mockito.ArgumentMatchers.any())).thenReturn(singlePage(sampleResponse()));
 
             mockMvc.perform(get("/api/projects"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status").value("success"))
-                    .andExpect(jsonPath("$.data[0].name").value("NexHub"))
-                    .andExpect(jsonPath("$.data[0].ownerUsername").value("manu"));
+                    .andExpect(jsonPath("$.data.content[0].name").value("NexHub"))
+                    .andExpect(jsonPath("$.data.content[0].ownerUsername").value("manu"));
         }
     }
 
@@ -83,12 +89,13 @@ class ProjectControllerTest {
 
         @Test
         void returnsFilteredProjects() throws Exception {
-            when(projectService.getProjectsByTag("AI")).thenReturn(List.of(sampleResponse()));
+            when(projectService.getProjectsByTag(org.mockito.ArgumentMatchers.eq("AI"), org.mockito.ArgumentMatchers.any()))
+                    .thenReturn(singlePage(sampleResponse()));
 
             mockMvc.perform(get("/api/projects/findbytag").param("tag", "AI"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status").value("success"))
-                    .andExpect(jsonPath("$.data[0].tags[0]").value("AI"));
+                    .andExpect(jsonPath("$.data.content[0].tags[0]").value("AI"));
         }
     }
 
@@ -211,6 +218,10 @@ class ProjectControllerTest {
                     .andExpect(jsonPath("$.message").value("Updated correctly"))
                     .andExpect(jsonPath("$.data.name").value("NexHub API"));
         }
+    }
+
+    private static PagedResponse<ProjectResponse> singlePage(ProjectResponse response) {
+        return PagedResponse.fromPage(new PageImpl<>(List.of(response), PageRequest.of(0, 9), 1));
     }
 
     private static ProjectResponse sampleResponse() {

--- a/src/test/java/com/nexhub/backend/service/ProjectServiceTest.java
+++ b/src/test/java/com/nexhub/backend/service/ProjectServiceTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 import java.sql.Date;
 import java.util.List;
@@ -91,12 +93,13 @@ class ProjectServiceTest {
         @Test
         void returnsOnlyProjectsMatchingTag() {
             Project project = sampleProject();
-            when(projectRepository.findDistinctByTags_NameIgnoreCase("AI")).thenReturn(List.of(project));
+            when(projectRepository.findDistinctByTags_NameIgnoreCase(org.mockito.ArgumentMatchers.eq("AI"), any()))
+                    .thenReturn(new PageImpl<>(List.of(project), PageRequest.of(0, 9), 1));
 
-            List<ProjectResponse> response = projectService.getProjectsByTag("AI");
+            var response = projectService.getProjectsByTag("AI", PageRequest.of(0, 9));
 
-            assertThat(response).hasSize(1);
-            assertThat(response.get(0).name()).isEqualTo("NexHub");
+            assertThat(response.content()).hasSize(1);
+            assertThat(response.content().get(0).name()).isEqualTo("NexHub");
         }
     }
 


### PR DESCRIPTION
Added reusable paginated response shape
Added pagination to projects list endpoints
Added pagination to tasks list endpoints
Added pagination to task assignments endpoints
Added pagination to task submissions endpoints
Added tasks by owner paginated endpoint
Added submissions to review by reviewer paginated endpoint
Added openOnly support for assigned tasks endpoint
Fixed public tasks query to exclude cancelled tasks from pagination
Removed broken project/task default sorting that was crashing requests